### PR TITLE
fix: update Go to 1.24.4 to resolve CVE-2025-22874 security vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Build stage - Use latest 1.24.2 Alpine image
-FROM golang:1.24.2-alpine AS builder
+# Build stage - Use latest 1.24.4 Alpine image
+FROM golang:1.24.4-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Fix critical security vulnerability in Go standard library by updating from version 1.24.2 to 1.24.4.

## Security Issue

**CVE-2025-22874** - HIGH Severity (CVSS: 7.5)
- **Component**: Go stdlib crypto/x509 package
- **Issue**: Usage of ExtKeyUsageAny disables policy validation
- **Impact**: Unintentionally disabled policy validation for certificate chains containing policy graphs

## Fix Applied

- Update Dockerfile: `FROM golang:1.24.2-alpine` → `FROM golang:1.24.4-alpine`
- Resolves CI/CD security scanner blocking deployment
- Maintains all existing functionality with security patch

## Test Plan

- [x] Code builds successfully with Go 1.24.4
- [x] No breaking changes to existing functionality  
- [x] Security scanner should now pass CI/CD pipeline
- [x] Docker image builds and runs correctly

## References

- [CVE-2025-22874 Details](https://nvd.nist.gov/vuln/detail/CVE-2025-22874)
- [Go Security Advisory](https://pkg.go.dev/vuln/GO-2025-3749)
- [Fix Commit](https://go.dev/cl/670375)

🤖 Generated with [Claude Code](https://claude.ai/code)