### PR TITLE
fix: resolve crash loop and Torn API schema change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Build stage - Use latest 1.24.6 Alpine image
-FROM golang:1.24.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.6-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -13,7 +16,7 @@ RUN go mod download && go mod verify
 COPY . .
 
 # Build the application with build info and security flags
-RUN CGO_ENABLED=0 GOOS=linux go build \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -a \
     -installsuffix cgo \
     -ldflags='-w -s -extldflags "-static"' \

--- a/internal/processing/provided.go
+++ b/internal/processing/provided.go
@@ -2,7 +2,6 @@ package processing
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"torn_oc_items/internal/config"
@@ -36,10 +35,10 @@ func ProcessProvidedItems(ctx context.Context, tornClient *torn.Client, sheetsCl
 		Msg("Parsed sheet items")
 
 	// Get item send logs from all providers
-	logResp := providers.AggregateLogs(ctx, providerList)
+	logEntries := providers.AggregateLogs(ctx, providerList)
 
 	// Find sheet rows that need provider updates
-	updates := FindProviderUpdates(ctx, tornClient, sheetItems, logResp)
+	updates := FindProviderUpdates(ctx, tornClient, sheetItems, logEntries)
 	if len(updates) > 0 {
 		log.Debug().
 			Int("updates", len(updates)).
@@ -51,17 +50,16 @@ func ProcessProvidedItems(ctx context.Context, tornClient *torn.Client, sheetsCl
 }
 
 // FindProviderUpdates finds updates for sheet items based on provider logs
-func FindProviderUpdates(ctx context.Context, tornClient *torn.Client, sheetItems []sheets.SheetItem, logResp *torn.LogResponse) []sheets.SheetRowUpdate {
+func FindProviderUpdates(ctx context.Context, tornClient *torn.Client, sheetItems []sheets.SheetItem, logEntries []providers.ProviderLogEntry) []sheets.SheetRowUpdate {
 	var updates []sheets.SheetRowUpdate
 
 	log.Debug().
 		Int("sheet_items", len(sheetItems)).
-		Int("log_entries", len(logResp.Log)).
+		Int("log_entries", len(logEntries)).
 		Msg("Starting provider update matching")
 
-	for combinedID, logEntry := range logResp.Log {
-		providerName := extractProviderName(combinedID)
-		logEntryUpdates := processLogEntryForUpdates(ctx, tornClient, logEntry, providerName, sheetItems)
+	for _, ple := range logEntries {
+		logEntryUpdates := processLogEntryForUpdates(ctx, tornClient, ple.Entry, ple.ProviderName, sheetItems)
 		updates = append(updates, logEntryUpdates...)
 	}
 
@@ -70,15 +68,6 @@ func FindProviderUpdates(ctx context.Context, tornClient *torn.Client, sheetItem
 		Msg("Completed provider update matching")
 
 	return updates
-}
-
-// extractProviderName extracts the provider name from combinedID format: providerName|logID
-func extractProviderName(combinedID string) string {
-	parts := strings.SplitN(combinedID, "|", 2)
-	if len(parts) == 2 {
-		return parts[0]
-	}
-	return "Unknown"
 }
 
 // processLogEntryForUpdates processes a single log entry and returns any updates found

--- a/internal/processing/supplied.go
+++ b/internal/processing/supplied.go
@@ -17,7 +17,8 @@ func GetSuppliedItems(ctx context.Context, tornClient *torn.Client) []torn.Suppl
 
 	suppliedItems, err := tornClient.GetSuppliedItems(ctx)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to get supplied items")
+		log.Error().Err(err).Msg("Failed to get supplied items, skipping this cycle")
+		return nil
 	}
 
 	callsAfter := tornClient.GetAPICallCount()

--- a/internal/providers/manager.go
+++ b/internal/providers/manager.go
@@ -15,6 +15,12 @@ type Provider struct {
 	Client *torn.Client
 }
 
+// ProviderLogEntry pairs a log entry with the provider name that fetched it.
+type ProviderLogEntry struct {
+	ProviderName string
+	Entry        torn.LogEntry
+}
+
 // LoadProviders reads PROVIDER_KEYS from the environment (comma-separated list of Torn API keys),
 // resolves each key to a player name via WhoAmI, and returns a slice of Provider instances.
 // Invalid keys are skipped with a warning.
@@ -40,20 +46,19 @@ func LoadProviders(ctx context.Context) []Provider {
 }
 
 // AggregateLogs fetches item-send logs for the last 48h from all providers and
-// returns a combined LogResponse containing entries tagged by provider.
-func AggregateLogs(ctx context.Context, provs []Provider) *torn.LogResponse {
-	combined := &torn.LogResponse{Log: make(map[string]torn.LogEntry)}
+// returns a slice of ProviderLogEntry with each entry tagged with its provider name.
+func AggregateLogs(ctx context.Context, provs []Provider) []ProviderLogEntry {
+	var combined []ProviderLogEntry
 	for _, p := range provs {
 		resp, err := p.Client.GetItemSendLogs(ctx)
 		if err != nil {
 			log.Warn().Err(err).Str("provider", p.Name).Msg("Failed to fetch logs for provider")
 			continue
 		}
-		for id, entry := range resp.Log {
-			// ensure uniqueness with provider prefix
-			combined.Log[p.Name+"|"+id] = entry
+		for _, entry := range resp.Log {
+			combined = append(combined, ProviderLogEntry{ProviderName: p.Name, Entry: entry})
 		}
 	}
-	log.Debug().Int("combined_log_entries", len(combined.Log)).Msg("Aggregated logs from all providers")
+	log.Debug().Int("combined_log_entries", len(combined)).Msg("Aggregated logs from all providers")
 	return combined
 }

--- a/internal/torn/client.go
+++ b/internal/torn/client.go
@@ -128,7 +128,7 @@ type LogEntry struct {
 }
 
 type LogResponse struct {
-	Log map[string]LogEntry `json:"log"`
+	Log []LogEntry `json:"log"`
 }
 
 func min(a, b int) int {
@@ -515,17 +515,14 @@ func (c *Client) GetItemSendLogs(ctx context.Context) (*LogResponse, error) {
 			Int("log_entries_count", len(logResp.Log)).
 			Msg("Successfully parsed log response")
 
-		// Log a few sample log IDs if available
+		// Log a few sample entries if available
 		if len(logResp.Log) > 0 {
-			count := 0
-			for logID := range logResp.Log {
-				if count >= 3 {
-					break
-				}
+			count := min(3, len(logResp.Log))
+			for i := 0; i < count; i++ {
 				log.Debug().
-					Str("sample_log_id", logID).
-					Msg("Sample log entry ID")
-				count++
+					Int("log_entry_index", i).
+					Int("log_type", logResp.Log[i].Log).
+					Msg("Sample log entry")
 			}
 		}
 


### PR DESCRIPTION
## Summary

- **Crash loop fix**: `GetSuppliedItems` was calling `log.Fatal` when the faction crimes API timed out transiently, causing 278 restarts over 96 days. Changed to `log.Error` + return nil so the cycle is skipped gracefully.
- **Torn API schema fix**: The `log` field in the user logs endpoint changed from `map[string]LogEntry` to `[]LogEntry`. Updated `LogResponse`, `AggregateLogs`, and `FindProviderUpdates` to use a slice. Added `ProviderLogEntry` type to carry provider name through aggregation (previously embedded in the map key as `"providerName|id"`).
- **Multi-arch Dockerfile**: Added `--platform=$BUILDPLATFORM`, `ARG TARGETOS/TARGETARCH`, and `GOOS/GOARCH` for true cross-compilation to arm64 (avoids QEMU emulation).

## Test plan

- [x] `go build ./...` passes cleanly
- [ ] CI builds linux/amd64 + linux/arm64 image successfully
- [ ] Deploy to pi cluster and confirm 0 restarts after stabilisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)