### PR TITLE
fix: update Go to 1.26.0 to resolve security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Build stage - Use latest 1.24.6 Alpine image
-FROM --platform=$BUILDPLATFORM golang:1.24.6-alpine AS builder
+# Build stage - Use latest 1.26.0 Alpine image
+FROM --platform=$BUILDPLATFORM golang:1.26.0-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module torn_oc_items
 
-go 1.24.6
+go 1.26.0
 
 require (
 	github.com/joho/godotenv v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module torn_oc_items
 
-go 1.26.0
+go 1.24.6
 
 require (
 	github.com/joho/godotenv v1.5.1


### PR DESCRIPTION
## Summary

Updates Go builder from 1.24.6 → 1.26.0 to resolve Trivy-detected CVEs in the Go stdlib:

| CVE | Severity | Package | Description |
|-----|----------|---------|-------------|
| CVE-2025-68121 | CRITICAL | crypto/tls | Unexpected session resumption |
| CVE-2025-61730 | HIGH | crypto/tls | TLS 1.3 handshake record handling |
| CVE-2025-61729 | HIGH | crypto/x509 | DoS via crafted certificate |
| CVE-2025-61728 | HIGH | archive/zip | Excessive CPU consumption |
| CVE-2025-61726 | HIGH | net/url | Memory exhaustion in query parsing |
| CVE-2025-58183 | HIGH | archive/tar | Unbounded allocation in GNU sparse map |

## Test plan

- [x] `go build ./...` passes with Go 1.26.0 toolchain
- [ ] CI builds linux/amd64 + linux/arm64 image cleanly
- [ ] Trivy scan passes with no CRITICAL/HIGH findings
- [ ] Rolling update to pi cluster with 0 restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)