### PR TITLE
Add source-code annotation to deployment manifest

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: torn-oc-items
   namespace: default
+  annotations:
+    app.kubernetes.io/source-code: "git@github.com:mnuck/torn-oc-items.git"
   labels:
     app: torn-oc-items
 spec:


### PR DESCRIPTION
Adds `app.kubernetes.io/source-code` annotation to the deployment so the repo location is discoverable from the cluster when debugging.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>